### PR TITLE
add overflow: hidden to prevent scrollbar on page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,7 @@ body {
   font-family: Roboto, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  overflow-x: hidden;
 }
 
 code {


### PR DESCRIPTION
To fix the horizontal scroll bar on the bottom issue:

<img width="1393" alt="Screen Shot 2021-01-19 at 2 33 24 PM" src="https://user-images.githubusercontent.com/588921/105173050-7bc29c80-5aee-11eb-8dcc-c87c23e09a5a.png">
